### PR TITLE
Parents children seeds

### DIFF
--- a/src/main/java/com/github/polimi_mt_acg/back2school/model/User.java
+++ b/src/main/java/com/github/polimi_mt_acg/back2school/model/User.java
@@ -68,11 +68,11 @@ public class User implements DeserializeToPersistInterface {
   )
   private List<Notification> notificationsRead = new ArrayList<>();
 
-  @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+  @ManyToMany(cascade = CascadeType.ALL)
   @JoinTable(
       name = "parent_children",
-      joinColumns = @JoinColumn(name = "child_id"),
-      inverseJoinColumns = @JoinColumn(name = "user_id"))
+      joinColumns = @JoinColumn(name = "parent_id"),
+      inverseJoinColumns = @JoinColumn(name = "child_id"))
   private List<User> children = new ArrayList<>();
 
   @Override

--- a/src/main/resources/hibernate.cfg.xml.template
+++ b/src/main/resources/hibernate.cfg.xml.template
@@ -30,6 +30,7 @@
         <mapping class="com.github.polimi_mt_acg.back2school.model.NotificationPersonalTeacher"/>
         <mapping class="com.github.polimi_mt_acg.back2school.model.Payment"/>
         <mapping class="com.github.polimi_mt_acg.back2school.model.SeedDummy"/>
+        <mapping class="com.github.polimi_mt_acg.back2school.utils.json_mappers.SeedEntityParentChild"/>
         <mapping class="com.github.polimi_mt_acg.back2school.utils.json_mappers.SeedEntityNotificationRead"/>
         <mapping class="com.github.polimi_mt_acg.back2school.model.Subject"/>
         <mapping class="com.github.polimi_mt_acg.back2school.model.User"/>

--- a/src/test/java/com/github/polimi_mt_acg/back2school/api/v1/SubjectsResourceTest.java
+++ b/src/test/java/com/github/polimi_mt_acg/back2school/api/v1/SubjectsResourceTest.java
@@ -69,7 +69,7 @@ public class SubjectsResourceTest {
   }
 
   @Test
-  @Category(TestCategory.Transient.class)
+  @Category(TestCategory.Endpoint.class)
   public void getSubjects() {
     // Get an admin
     User admin = get(Role.ADMINISTRATOR);
@@ -91,7 +91,7 @@ public class SubjectsResourceTest {
   }
 
   @Test
-  @Category(TestCategory.Transient.class)
+  @Category(TestCategory.Endpoint.class)
   public void postSubjects() {
 
     URI resourceURI = postMate(0);
@@ -100,7 +100,7 @@ public class SubjectsResourceTest {
   }
 
   @Test
-  @Category(TestCategory.Transient.class)
+  @Category(TestCategory.Endpoint.class)
   public void getSubjectID() throws JsonProcessingException {
     // Create a new Classroom in the system
     URI mateURI = postMate(1);
@@ -148,7 +148,7 @@ public class SubjectsResourceTest {
   }
 
   @Test
-  @Category(TestCategory.Transient.class)
+  @Category(TestCategory.Endpoint.class)
   public void putSubjectById() throws JsonProcessingException {
     // Get an admin
     User admin = get(Role.ADMINISTRATOR);

--- a/src/test/java/com/github/polimi_mt_acg/back2school/model/ParentChildrenTest.java
+++ b/src/test/java/com/github/polimi_mt_acg/back2school/model/ParentChildrenTest.java
@@ -1,0 +1,59 @@
+package com.github.polimi_mt_acg.back2school.model;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import com.github.polimi_mt_acg.back2school.utils.DatabaseHandler;
+import com.github.polimi_mt_acg.back2school.utils.DatabaseSeeder;
+import com.github.polimi_mt_acg.back2school.utils.TestCategory;
+
+import java.util.Optional;
+
+import org.hibernate.Session;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+public class ParentChildrenTest {
+
+  @BeforeClass
+  public static void oneTimeSetUp() {
+    // Deploy database scenario
+    DatabaseSeeder.deployScenario("scenarioA_unit_tests");
+  }
+
+  @AfterClass
+  public static void oneTimeTearDown() {
+    // Truncate DB
+    DatabaseHandler.getInstance().truncateDatabase();
+  }
+
+  @Test
+  @Category(TestCategory.Unit.class)
+  public void testBobChildren() {
+    Session session = DatabaseHandler.getInstance().getNewSession();
+    Optional<User> bobOpt =
+        DatabaseHandler.fetchEntityBy(User.class, User_.email, "bob@email.com", session);
+
+    assertTrue(bobOpt.isPresent());
+    User bob = bobOpt.get();
+
+    assertEquals(2, bob.getChildren().size());
+    session.close();
+  }
+
+  @Test
+  @Category(TestCategory.Unit.class)
+  public void testBob2Children() {
+    Session session = DatabaseHandler.getInstance().getNewSession();
+    Optional<User> bob2Opt =
+        DatabaseHandler.fetchEntityBy(User.class, User_.email, "bob2@email.com", session);
+
+    assertTrue(bob2Opt.isPresent());
+    User bob2 = bob2Opt.get();
+
+    assertEquals(1, bob2.getChildren().size());
+    session.close();
+  }
+}

--- a/src/test/java/com/github/polimi_mt_acg/back2school/utils/DatabaseSeeder.java
+++ b/src/test/java/com/github/polimi_mt_acg/back2school/utils/DatabaseSeeder.java
@@ -5,18 +5,8 @@ import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.polimi_mt_acg.back2school.model.DeserializeToPersistInterface;
 import com.github.polimi_mt_acg.back2school.model.User;
-import com.github.polimi_mt_acg.back2school.utils.json_mappers.AppointmentsJSONTemplate;
-import com.github.polimi_mt_acg.back2school.utils.json_mappers.AuthenticationSessionJSONTemplate;
-import com.github.polimi_mt_acg.back2school.utils.json_mappers.ClassesJSONTemplate;
-import com.github.polimi_mt_acg.back2school.utils.json_mappers.ClassroomsJSONTemplate;
-import com.github.polimi_mt_acg.back2school.utils.json_mappers.GradesJSONTemplate;
-import com.github.polimi_mt_acg.back2school.utils.json_mappers.JSONTemplateInterface;
-import com.github.polimi_mt_acg.back2school.utils.json_mappers.LecturesJSONTemplate;
-import com.github.polimi_mt_acg.back2school.utils.json_mappers.NotificationsJSONTemplate;
-import com.github.polimi_mt_acg.back2school.utils.json_mappers.NotificationsReadJSONTemplate;
-import com.github.polimi_mt_acg.back2school.utils.json_mappers.PaymentsJSONTemplate;
-import com.github.polimi_mt_acg.back2school.utils.json_mappers.SubjectsJSONTemplate;
-import com.github.polimi_mt_acg.back2school.utils.json_mappers.UsersJSONTemplate;
+import com.github.polimi_mt_acg.back2school.utils.json_mappers.*;
+
 import java.io.File;
 import java.io.IOException;
 import java.util.Collections;
@@ -53,6 +43,7 @@ public class DatabaseSeeder {
      * [x] notification_personal_parent
      * [x] notification_personal_teacher
      * [x] notification_read
+     * [x] parent_children
      * [x] payment
      * [x] authentication_session
      */
@@ -62,6 +53,7 @@ public class DatabaseSeeder {
     map.put("users.json", UsersJSONTemplate.class);
 
     // one or more dependency from other entities
+    map.put("parent_children.json", ParentChildrenJSONTemplate.class);
     map.put("payments.json", PaymentsJSONTemplate.class);
     map.put("grades.json", GradesJSONTemplate.class);
     map.put("classes.json", ClassesJSONTemplate.class);

--- a/src/test/java/com/github/polimi_mt_acg/back2school/utils/json_mappers/ParentChildrenJSONTemplate.java
+++ b/src/test/java/com/github/polimi_mt_acg/back2school/utils/json_mappers/ParentChildrenJSONTemplate.java
@@ -1,0 +1,16 @@
+package com.github.polimi_mt_acg.back2school.utils.json_mappers;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+public class ParentChildrenJSONTemplate implements JSONTemplateInterface {
+
+  @JsonProperty("parent_children")
+  public List<SeedEntityParentChild> parentChildren;
+
+  @Override
+  public List<?> getEntities() {
+    return parentChildren;
+  }
+}

--- a/src/test/java/com/github/polimi_mt_acg/back2school/utils/json_mappers/SeedEntityParentChild.java
+++ b/src/test/java/com/github/polimi_mt_acg/back2school/utils/json_mappers/SeedEntityParentChild.java
@@ -1,0 +1,88 @@
+package com.github.polimi_mt_acg.back2school.utils.json_mappers;
+
+import com.github.polimi_mt_acg.back2school.model.SeedDummy;
+import com.github.polimi_mt_acg.back2school.model.User;
+import com.github.polimi_mt_acg.back2school.model.User_;
+import com.github.polimi_mt_acg.back2school.utils.DatabaseHandler;
+import org.hibernate.Session;
+
+import javax.persistence.Entity;
+import javax.persistence.Transient;
+import java.util.Optional;
+
+import static com.github.polimi_mt_acg.back2school.utils.PythonMockedUtilityFunctions.print;
+
+@Entity
+public class SeedEntityParentChild extends SeedDummy {
+
+  @Transient public String seedParentEmail;
+
+  @Transient public String seedChildEmail;
+
+  @Override
+  public void prepareToPersist() {
+    super.prepareToPersist();
+    seedAssociateChildToParent();
+  }
+
+  private void seedAssociateChildToParent() {
+    Session session = DatabaseHandler.getInstance().getNewSession();
+
+    session.beginTransaction();
+
+    Optional<User> parentOpt =
+        DatabaseHandler.fetchEntityBy(User.class, User_.email, seedParentEmail, session);
+
+    Optional<User> childOpt =
+        DatabaseHandler.fetchEntityBy(User.class, User_.email, seedChildEmail, session);
+
+    // if the parent is not found into the database
+    if (!parentOpt.isPresent()) {
+      print(
+          "WARNING! parent_child.json found seedParentEmail: ",
+          seedParentEmail,
+          " BUT there IS NO corresponding user in the database.");
+      print("PARENT-CHILD relation NOT created!");
+      return;
+    }
+
+    // if the child is not found into the database
+    if (!childOpt.isPresent()) {
+      print(
+          "WARNING! parent_child.json found seedChildEmail: ",
+          seedChildEmail,
+          " BUT there IS NO corresponding user in the database.");
+      print("PARENT-CHILD relation NOT created!");
+      return;
+    }
+
+    User parent = parentOpt.get();
+    User child = childOpt.get();
+
+    if (!parent.getRole().equals(User.Role.PARENT)) {
+      print(
+          "WARNING! parent_child.json found seedParentEmail: ",
+          seedParentEmail,
+          " with role: ",
+          parent.getRole(),
+          " INSTEAD of PARENT.");
+      print("PARENT-CHILD relation NOT created!");
+      return;
+    }
+    if (!child.getRole().equals(User.Role.STUDENT)) {
+      print(
+          "WARNING! parent_child.json found seedChildEmail: ",
+          seedChildEmail,
+          " with role: ",
+          child.getRole(),
+          " INSTEAD of STUDENT.");
+      print("PARENT-CHILD relation NOT created!");
+      return;
+    }
+
+    parent.addChild(child);
+
+    session.getTransaction().commit();
+    session.close();
+  }
+}

--- a/src/test/resources/hibernate.cfg.xml.template
+++ b/src/test/resources/hibernate.cfg.xml.template
@@ -30,6 +30,7 @@
         <mapping class="com.github.polimi_mt_acg.back2school.model.NotificationPersonalTeacher"/>
         <mapping class="com.github.polimi_mt_acg.back2school.model.Payment"/>
         <mapping class="com.github.polimi_mt_acg.back2school.model.SeedDummy"/>
+        <mapping class="com.github.polimi_mt_acg.back2school.utils.json_mappers.SeedEntityParentChild"/>
         <mapping class="com.github.polimi_mt_acg.back2school.utils.json_mappers.SeedEntityNotificationRead"/>
         <mapping class="com.github.polimi_mt_acg.back2school.model.Subject"/>
         <mapping class="com.github.polimi_mt_acg.back2school.model.User"/>

--- a/src/test/resources/scenarios_seeds/scenarioA_unit_tests/parent_children.json
+++ b/src/test/resources/scenarios_seeds/scenarioA_unit_tests/parent_children.json
@@ -1,0 +1,16 @@
+{
+  "parent_children": [
+    {
+      "seedParentEmail": "bob@email.com",
+      "seedChildEmail": "edmond@email.com"
+    },
+    {
+      "seedParentEmail": "bob@email.com",
+      "seedChildEmail": "finn@email.com"
+    },
+    {
+      "seedParentEmail": "bob2@email.com",
+      "seedChildEmail": "alice1@email.com"
+    }
+  ]
+}

--- a/src/test/resources/scenarios_seeds/scenarioA_unit_tests/users.json
+++ b/src/test/resources/scenarios_seeds/scenarioA_unit_tests/users.json
@@ -27,6 +27,34 @@
       "surname": "SurnameDavid",
       "email": "david@email.com",
       "seedPassword": "david_password"
+    },
+    {
+      "role": "STUDENT",
+      "name": "Edmond",
+      "surname": "SurnameEdmond",
+      "email": "edmond@email.com",
+      "seedPassword": "edmond_password"
+    },
+    {
+      "role": "STUDENT",
+      "name": "Finn",
+      "surname": "SurnameFinn",
+      "email": "finn@email.com",
+      "seedPassword": "finn_password"
+    },
+    {
+      "role": "PARENT",
+      "name": "Bob2",
+      "surname": "SurnameBob2",
+      "email": "bob2@email.com",
+      "seedPassword": "bob2_password"
+    },
+    {
+      "role": "STUDENT",
+      "name": "Alice1",
+      "surname": "SurnameAlice1",
+      "email": "alice1@email.com",
+      "seedPassword": "alice1_password"
     }
   ]
 }


### PR DESCRIPTION
- Implemented the feature to deploy relationships between parent and children via seed file.
- Reverted back to `Endpoint` the test category of `SubjectResourceTest` class's tests. #17 -> [comment](https://github.com/polimi-mt-acg/back2school/pull/16/files/966f0253ee463c54d57fee2ed511d095fd5df8af#diff-b1aef6b76b44673e0d38df1a2e66f2b0R72)

@gregorigiacomo @leonardoarcari please update the hibernate.cfg.xml files from their templates.