### PR TITLE
DatabaseHandler destroy() method to close connections pool

### DIFF
--- a/src/main/java/com/github/polimi_mt_acg/back2school/utils/DatabaseHandler.java
+++ b/src/main/java/com/github/polimi_mt_acg/back2school/utils/DatabaseHandler.java
@@ -20,14 +20,12 @@ import org.hibernate.mapping.Table;
 
 public class DatabaseHandler {
 
-  private static final Logger LOGGER;
-  private static final StandardServiceRegistry registry;
-  private static final SessionFactory sessionFactory;
+  private static final Logger LOGGER = Logger.getLogger(DatabaseHandler.class.getName());
+  private static volatile StandardServiceRegistry registry;
+  private static volatile SessionFactory sessionFactory;
   private static volatile DatabaseHandler instance;
 
-  static {
-    LOGGER = Logger.getLogger(DatabaseHandler.class.getName());
-
+  private DatabaseHandler() {
     // Initialize once the register
     registry =
         new StandardServiceRegistryBuilder()
@@ -45,8 +43,6 @@ public class DatabaseHandler {
       throw e;
     }
   }
-
-  private DatabaseHandler() {}
 
   public static DatabaseHandler getInstance() {
     if (instance == null) {
@@ -220,5 +216,13 @@ public class DatabaseHandler {
       return Optional.empty();
     }
     return Optional.of(res.get(0));
+  }
+
+  /** Destroy the current DatabaseHandler instance by closing also the sessionFactory created. */
+  public void destroy() {
+    sessionFactory.close();
+
+    // empty the current instance
+    instance = null;
   }
 }

--- a/src/test/java/com/github/polimi_mt_acg/back2school/api/v1/AdministratorResourceTest.java
+++ b/src/test/java/com/github/polimi_mt_acg/back2school/api/v1/AdministratorResourceTest.java
@@ -47,6 +47,7 @@ public class AdministratorResourceTest {
   public static void tearDown() throws Exception {
     // Truncate DB
     DatabaseHandler.getInstance().truncateDatabase();
+    DatabaseHandler.getInstance().destroy();
 
     // Close HTTP server
     server.shutdownNow();

--- a/src/test/java/com/github/polimi_mt_acg/back2school/api/v1/ClassroomsResourceTest.java
+++ b/src/test/java/com/github/polimi_mt_acg/back2school/api/v1/ClassroomsResourceTest.java
@@ -62,6 +62,7 @@ public class ClassroomsResourceTest {
   public static void tearDown() throws Exception {
     // Truncate DB
     DatabaseHandler.getInstance().truncateDatabase();
+    DatabaseHandler.getInstance().destroy();
 
     // Close HTTP server
     server.shutdownNow();

--- a/src/test/java/com/github/polimi_mt_acg/back2school/api/v1/NotificationsResourceTest.java
+++ b/src/test/java/com/github/polimi_mt_acg/back2school/api/v1/NotificationsResourceTest.java
@@ -48,6 +48,7 @@ public class NotificationsResourceTest {
   public static void tearDown() throws Exception {
     // Truncate DB
     DatabaseHandler.getInstance().truncateDatabase();
+    DatabaseHandler.getInstance().destroy();
 
     // Close HTTP server
     server.shutdownNow();

--- a/src/test/java/com/github/polimi_mt_acg/back2school/api/v1/StudentsResourceTest.java
+++ b/src/test/java/com/github/polimi_mt_acg/back2school/api/v1/StudentsResourceTest.java
@@ -46,6 +46,7 @@ public class StudentsResourceTest {
   public static void setUp() throws Exception {
     // Deploy database scenario
     DatabaseSeeder.deployScenario("scenarioStudents");
+    DatabaseHandler.getInstance().destroy();
 
     // Run HTTP server
     server =

--- a/src/test/java/com/github/polimi_mt_acg/back2school/api/v1/SubjectsResourceTest.java
+++ b/src/test/java/com/github/polimi_mt_acg/back2school/api/v1/SubjectsResourceTest.java
@@ -7,10 +7,8 @@ import static org.junit.Assert.assertTrue;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.polimi_mt_acg.back2school.api.v1.auth.AuthenticationResource;
-import com.github.polimi_mt_acg.back2school.api.v1.subjects.*;
 import com.github.polimi_mt_acg.back2school.api.v1.subjects.PutSubjectRequest;
 import com.github.polimi_mt_acg.back2school.api.v1.subjects.SubjectsResponse;
-import com.github.polimi_mt_acg.back2school.model.Class;
 import com.github.polimi_mt_acg.back2school.model.Subject;
 import com.github.polimi_mt_acg.back2school.model.User;
 import com.github.polimi_mt_acg.back2school.model.User.Role;
@@ -20,7 +18,6 @@ import com.github.polimi_mt_acg.back2school.utils.JacksonCustomMapper;
 import com.github.polimi_mt_acg.back2school.utils.TestCategory;
 import com.github.polimi_mt_acg.back2school.utils.rest.HTTPServerManager;
 import com.github.polimi_mt_acg.back2school.utils.rest.RestFactory;
-import java.io.IOException;
 import java.net.URI;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -28,9 +25,6 @@ import java.util.List;
 import java.util.stream.Collectors;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.client.Invocation;
-import javax.ws.rs.client.WebTarget;
-import javax.ws.rs.core.HttpHeaders;
-import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 import org.glassfish.grizzly.http.server.HttpServer;
@@ -63,6 +57,7 @@ public class SubjectsResourceTest {
   public static void tearDown() throws Exception {
     // Truncate DB
     DatabaseHandler.getInstance().truncateDatabase();
+    DatabaseHandler.getInstance().destroy();
 
     // Close HTTP server
     server.shutdownNow();

--- a/src/test/java/com/github/polimi_mt_acg/back2school/api/v1/TeacherResourceTest.java
+++ b/src/test/java/com/github/polimi_mt_acg/back2school/api/v1/TeacherResourceTest.java
@@ -53,6 +53,7 @@ public class TeacherResourceTest {
   public static void oneTimeTearDown() {
     // Truncate DB
     DatabaseHandler.getInstance().truncateDatabase();
+    DatabaseHandler.getInstance().destroy();
 
     // Close HTTP server
     server.shutdownNow();

--- a/src/test/java/com/github/polimi_mt_acg/back2school/model/AppointmentTest.java
+++ b/src/test/java/com/github/polimi_mt_acg/back2school/model/AppointmentTest.java
@@ -22,6 +22,7 @@ public class AppointmentTest {
   @AfterClass
   public static void tearDownClass() {
     DatabaseHandler.getInstance().truncateDatabase();
+    DatabaseHandler.getInstance().destroy();
   }
 
   @Test

--- a/src/test/java/com/github/polimi_mt_acg/back2school/model/AuthenticationSessionTest.java
+++ b/src/test/java/com/github/polimi_mt_acg/back2school/model/AuthenticationSessionTest.java
@@ -23,6 +23,7 @@ public class AuthenticationSessionTest {
   @AfterClass
   public static void tearDownClass() {
     DatabaseHandler.getInstance().truncateDatabase();
+    DatabaseHandler.getInstance().destroy();
   }
 
   @Test

--- a/src/test/java/com/github/polimi_mt_acg/back2school/model/ClassTest.java
+++ b/src/test/java/com/github/polimi_mt_acg/back2school/model/ClassTest.java
@@ -22,6 +22,7 @@ public class ClassTest {
   @AfterClass
   public static void tearDownClass() {
     DatabaseHandler.getInstance().truncateDatabase();
+    DatabaseHandler.getInstance().destroy();
   }
 
   @Test

--- a/src/test/java/com/github/polimi_mt_acg/back2school/model/ClassroomTest.java
+++ b/src/test/java/com/github/polimi_mt_acg/back2school/model/ClassroomTest.java
@@ -22,6 +22,7 @@ public class ClassroomTest {
   @AfterClass
   public static void tearDownClass() {
     DatabaseHandler.getInstance().truncateDatabase();
+    DatabaseHandler.getInstance().destroy();
   }
 
   @Test

--- a/src/test/java/com/github/polimi_mt_acg/back2school/model/GradeTest.java
+++ b/src/test/java/com/github/polimi_mt_acg/back2school/model/GradeTest.java
@@ -22,6 +22,7 @@ public class GradeTest {
   @AfterClass
   public static void tearDownClass() {
     DatabaseHandler.getInstance().truncateDatabase();
+    DatabaseHandler.getInstance().destroy();
   }
 
   @Test

--- a/src/test/java/com/github/polimi_mt_acg/back2school/model/LectureTest.java
+++ b/src/test/java/com/github/polimi_mt_acg/back2school/model/LectureTest.java
@@ -22,6 +22,7 @@ public class LectureTest {
   @AfterClass
   public static void tearDownClass() {
     DatabaseHandler.getInstance().truncateDatabase();
+    DatabaseHandler.getInstance().destroy();
   }
 
   @Test

--- a/src/test/java/com/github/polimi_mt_acg/back2school/model/NotificationTest.java
+++ b/src/test/java/com/github/polimi_mt_acg/back2school/model/NotificationTest.java
@@ -24,6 +24,7 @@ public class NotificationTest {
   @AfterClass
   public static void tearDownClass() {
     DatabaseHandler.getInstance().truncateDatabase();
+    DatabaseHandler.getInstance().destroy();
   }
 
   @Test
@@ -66,7 +67,8 @@ public class NotificationTest {
   @Category(TestCategory.Unit.class)
   public void testNotificationGeneralTeachersEntity() {
     NotificationGeneralTeachers seedEntity = getSeedEntity(NotificationGeneralTeachers.class);
-    NotificationGeneralTeachers databaseEntity = getDatabaseEntity(NotificationGeneralTeachers.class);
+    NotificationGeneralTeachers databaseEntity =
+        getDatabaseEntity(NotificationGeneralTeachers.class);
 
     // common asserts of Notification class
     testNotificationCommonAsserts(seedEntity, databaseEntity);
@@ -89,7 +91,8 @@ public class NotificationTest {
   @Category(TestCategory.Unit.class)
   public void testNotificationPersonalTeacherEntity() {
     NotificationPersonalTeacher seedEntity = getSeedEntity(NotificationPersonalTeacher.class);
-    NotificationPersonalTeacher databaseEntity = getDatabaseEntity(NotificationPersonalTeacher.class);
+    NotificationPersonalTeacher databaseEntity =
+        getDatabaseEntity(NotificationPersonalTeacher.class);
 
     // common asserts of Notification class
     testNotificationCommonAsserts(seedEntity, databaseEntity);

--- a/src/test/java/com/github/polimi_mt_acg/back2school/model/ParentChildrenTest.java
+++ b/src/test/java/com/github/polimi_mt_acg/back2school/model/ParentChildrenTest.java
@@ -27,6 +27,7 @@ public class ParentChildrenTest {
   public static void oneTimeTearDown() {
     // Truncate DB
     DatabaseHandler.getInstance().truncateDatabase();
+    DatabaseHandler.getInstance().destroy();
   }
 
   @Test

--- a/src/test/java/com/github/polimi_mt_acg/back2school/model/PaymentTest.java
+++ b/src/test/java/com/github/polimi_mt_acg/back2school/model/PaymentTest.java
@@ -22,6 +22,7 @@ public class PaymentTest {
   @AfterClass
   public static void tearDownClass() {
     DatabaseHandler.getInstance().truncateDatabase();
+    DatabaseHandler.getInstance().destroy();
   }
 
   @Test

--- a/src/test/java/com/github/polimi_mt_acg/back2school/model/SubjectTest.java
+++ b/src/test/java/com/github/polimi_mt_acg/back2school/model/SubjectTest.java
@@ -22,6 +22,7 @@ public class SubjectTest {
   @AfterClass
   public static void tearDownClass() {
     DatabaseHandler.getInstance().truncateDatabase();
+    DatabaseHandler.getInstance().destroy();
   }
 
   @Test

--- a/src/test/java/com/github/polimi_mt_acg/back2school/model/UserTest.java
+++ b/src/test/java/com/github/polimi_mt_acg/back2school/model/UserTest.java
@@ -23,6 +23,7 @@ public class UserTest {
   @AfterClass
   public static void tearDownClass() {
     DatabaseHandler.getInstance().truncateDatabase();
+    DatabaseHandler.getInstance().destroy();
   }
 
   @Test

--- a/src/test/java/com/github/polimi_mt_acg/back2school/utils/DatabaseHandlerTest.java
+++ b/src/test/java/com/github/polimi_mt_acg/back2school/utils/DatabaseHandlerTest.java
@@ -7,6 +7,7 @@ import com.github.polimi_mt_acg.back2school.model.User;
 import java.util.List;
 import javax.persistence.criteria.CriteriaQuery;
 import org.hibernate.Session;
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -18,6 +19,12 @@ public class DatabaseHandlerTest {
   @BeforeClass
   public static void setUpClass() {
     dbh = DatabaseHandler.getInstance();
+  }
+
+  @AfterClass
+  public static void tearDownClass() {
+    dbh.truncateDatabase();
+    dbh.destroy();
   }
 
   @Test
@@ -32,6 +39,7 @@ public class DatabaseHandlerTest {
   public void getNewSession() {
     Session session = dbh.getNewSession();
     assertNotNull(session);
+    session.close();
   }
 
   @Test

--- a/src/test/java/com/github/polimi_mt_acg/back2school/utils/DatabaseSeeder.java
+++ b/src/test/java/com/github/polimi_mt_acg/back2school/utils/DatabaseSeeder.java
@@ -82,8 +82,8 @@ public class DatabaseSeeder {
       List<?> entitiesToPersist = getEntitiesListFromSeed(scenarioFolderName, seedFilename);
 
       if (entitiesToPersist != null) {
-        Session s = DatabaseHandler.getInstance().getNewSession();
-        s.beginTransaction();
+        Session session = DatabaseHandler.getInstance().getNewSession();
+        session.beginTransaction();
         for (Object genericEntity : entitiesToPersist) {
           if (genericEntity instanceof DeserializeToPersistInterface) {
 
@@ -93,12 +93,11 @@ public class DatabaseSeeder {
             // notify the entity that it will be persisted
             entity.prepareToPersist();
 
-            s.persist(entity);
+            session.persist(entity);
           }
         }
-        s.getTransaction().commit();
-        s.close();
-
+        session.getTransaction().commit();
+        session.close();
         //                LOGGER.info(
         //                        String.format(
         //                                "deployed seed file: %s/%s",

--- a/src/test/java/com/github/polimi_mt_acg/back2school/utils/DatabaseSeederTest.java
+++ b/src/test/java/com/github/polimi_mt_acg/back2school/utils/DatabaseSeederTest.java
@@ -15,6 +15,7 @@ public class DatabaseSeederTest {
   public void deployScenario() {
     DatabaseSeeder.deployScenario("scenarioA_unit_tests");
     DatabaseHandler.getInstance().truncateDatabase();
+    DatabaseHandler.getInstance().destroy();
   }
 
   @Test


### PR DESCRIPTION
This method should be called once the DatabaseHandler instance is no more required (e.g. in the `@AfterClass` annotated method of tests). It will close the connections pool opened when the DatabaseHandler instance is created.

By not closing the connections pool opened towards the database, as it was before this method, the connections pool size will saturate up to the maximum when many connections are opened in parallel. Furthermore, by do not closing the connections pool, the database log contains errors about badly closed connections when tests end. Example:

```
mariadb_1     | 2018-08-01  7:02:04 154 [Warning] Aborted connection 154 to db: 'back2school' user: 'root' host: '192.168.0.1' (Got an error reading communication packets)
mariadb_1     | 2018-08-01  7:02:04 149 [Warning] Aborted connection 149 to db: 'back2school' user: 'root' host: '192.168.0.1' (Got an error reading communication packets)
mariadb_1     | 2018-08-01  7:02:04 152 [Warning] Aborted connection 152 to db: 'back2school' user: 'root' host: '192.168.0.1' (Got an error reading communication packets)
mariadb_1     | 2018-08-01  7:02:04 148 [Warning] Aborted connection 148 to db: 'back2school' user: 'root' host: '192.168.0.1' (Got an error reading communication packets)
mariadb_1     | 2018-08-01  7:02:04 156 [Warning] Aborted connection 156 to db: 'back2school' user: 'root' host: '192.168.0.1' (Got an error reading communication packets)
mariadb_1     | 2018-08-01  7:02:04 143 [Warning] Aborted connection 143 to db: 'back2school' user: 'root' host: '192.168.0.1' (Got an error reading communication packets)
mariadb_1     | 2018-08-01  7:02:04 155 [Warning] Aborted connection 155 to db: 'back2school' user: 'root' host: '192.168.0.1' (Got an error reading communication packets)
```