### PR TITLE
Add Wildfly deployment support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
       <groupId>javax.ws.rs</groupId>
       <artifactId>javax.ws.rs-api</artifactId>
       <version>2.1</version>
-      <scope>provided</scope>
+      <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.containers</groupId>

--- a/src/main/java/com/github/polimi_mt_acg/back2school/RESTApplication.java
+++ b/src/main/java/com/github/polimi_mt_acg/back2school/RESTApplication.java
@@ -1,0 +1,16 @@
+package com.github.polimi_mt_acg.back2school;
+
+import com.github.polimi_mt_acg.back2school.utils.JacksonCustomMapper;
+import javax.ws.rs.ApplicationPath;
+import org.glassfish.jersey.jackson.JacksonFeature;
+import org.glassfish.jersey.server.ResourceConfig;
+
+@ApplicationPath("v1")
+public class RESTApplication extends ResourceConfig {
+
+  public RESTApplication() {
+    packages("com.github.polimi_mt_acg.back2school");
+    register(JacksonCustomMapper.class);
+    register(JacksonFeature.class);
+  }
+}

--- a/src/main/java/com/github/polimi_mt_acg/back2school/api/v1/auth/AuthenticationResource.java
+++ b/src/main/java/com/github/polimi_mt_acg/back2school/api/v1/auth/AuthenticationResource.java
@@ -6,6 +6,7 @@ import com.github.polimi_mt_acg.back2school.model.User_;
 import com.github.polimi_mt_acg.back2school.utils.DatabaseHandler;
 import java.util.List;
 import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
@@ -58,7 +59,7 @@ public class AuthenticationResource {
     return Response.ok(token).build();
   }
 
-  @POST
+  @GET
   @Path("logout")
   public LogoutResponse userLogout(ContainerRequestContext requestContext) {
     User currentUser = AuthenticationSession.getCurrentUser(requestContext);

--- a/src/main/resources/hibernate.cfg.xml.template
+++ b/src/main/resources/hibernate.cfg.xml.template
@@ -30,8 +30,6 @@
         <mapping class="com.github.polimi_mt_acg.back2school.model.NotificationPersonalTeacher"/>
         <mapping class="com.github.polimi_mt_acg.back2school.model.Payment"/>
         <mapping class="com.github.polimi_mt_acg.back2school.model.SeedDummy"/>
-        <mapping class="com.github.polimi_mt_acg.back2school.utils.json_mappers.SeedEntityParentChild"/>
-        <mapping class="com.github.polimi_mt_acg.back2school.utils.json_mappers.SeedEntityNotificationRead"/>
         <mapping class="com.github.polimi_mt_acg.back2school.model.Subject"/>
         <mapping class="com.github.polimi_mt_acg.back2school.model.User"/>
     </session-factory>

--- a/web/WEB-INF/web.xml
+++ b/web/WEB-INF/web.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<web-app xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_4_0.xsd"
+  version="4.0">
+  <servlet>
+    <servlet-name>com.github.polimi_mt_acg.back2school.RESTApplication</servlet-name>
+  </servlet>
+  <servlet-mapping>
+    <servlet-name>com.github.polimi_mt_acg.back2school.RESTApplication</servlet-name>
+    <url-pattern>/v1/*</url-pattern>
+  </servlet-mapping>
+</web-app>


### PR DESCRIPTION
This PR should bring in the support to Wildfly deployment.
On successful deployment the APIs are available at the following base URL:

`http://hostname:port/package-name/v1/`

given that `hostname` and `port` are `localhost` and `8080` for local deployment and `package-name` depends on the name of the **WAR** file you deployed. 

Signed-off-by: Leonardo Arcari <lippol94@gmail.com>